### PR TITLE
Harden pods (seccomp/capabilities/non-root) and restrict psuite LoadBalancer access

### DIFF
--- a/clusters/titania/apps/dotbintask/deploy.yaml
+++ b/clusters/titania/apps/dotbintask/deploy.yaml
@@ -12,6 +12,9 @@ spec:
       labels:
         app: dotbintask
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       # Backend API container
       - name: api
@@ -35,6 +38,11 @@ spec:
           value: "/home/appuser/psuite-todo/taskrc"
         - name: TW_API_LOG_LEVEL
           value: "info"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
         resources:
           requests:
             memory: "128Mi"
@@ -64,6 +72,11 @@ spec:
         ports:
         - containerPort: 80
           name: http-frontend
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
         resources:
           requests:
             memory: "64Mi"
@@ -88,4 +101,3 @@ spec:
       - name: task-data
         persistentVolumeClaim:
           claimName: task-data-pvc
-

--- a/clusters/titania/apps/games/deploy.yaml
+++ b/clusters/titania/apps/games/deploy.yaml
@@ -14,10 +14,19 @@ spec:
       labels:
         app: wordle
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: modem7/wordle:latest
         imagePullPolicy: IfNotPresent
         name: wordle
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/clusters/titania/apps/psuite/psuite-service.yaml
+++ b/clusters/titania/apps/psuite/psuite-service.yaml
@@ -6,6 +6,10 @@ metadata:
     app: psuite
 spec:
   type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16
   ports:
   - port: 8384
     targetPort: 8384
@@ -22,6 +26,10 @@ metadata:
     app: psuite
 spec:
   type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16
   ports:
   - port: 22000
     targetPort: 22000
@@ -38,6 +46,10 @@ metadata:
     app: psuite
 spec:
   type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16
   ports:
   - port: 22000
     targetPort: 22000
@@ -54,6 +66,10 @@ metadata:
     app: psuite
 spec:
   type: LoadBalancer
+  loadBalancerSourceRanges:
+  - 10.0.0.0/8
+  - 172.16.0.0/12
+  - 192.168.0.0/16
   ports:
   - port: 21027
     targetPort: 21027

--- a/clusters/titania/apps/torrents/deluge/deluge-wireguard-deploy.yaml
+++ b/clusters/titania/apps/torrents/deluge/deluge-wireguard-deploy.yaml
@@ -71,8 +71,9 @@ spec:
         - name: NAME_SERVERS
           value: "1.1.1.1,1.0.0.1"
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
           capabilities:
+            drop: ["ALL"]
             add: ["NET_ADMIN"]
         volumeMounts:
         - name: wireguard-rw


### PR DESCRIPTION
### Motivation

- Improve runtime security of several applications by applying pod/container security contexts and dropping unnecessary capabilities.
- Constrain external exposure of `psuite` services by limiting `LoadBalancer` source ranges to private networks.
- Remove use of privileged containers where possible and enforce least-privilege networking for the Deluge VPN container.

### Description

- Added a pod-level `seccompProfile` set to `RuntimeDefault` and per-container `securityContext` entries for the `dotbintask` deployment in `clusters/titania/apps/dotbintask/deploy.yaml` and for the `wordle` deployment in `clusters/titania/apps/games/deploy.yaml` to enforce `runAsNonRoot`, `allowPrivilegeEscalation: false`, drop capabilities and make the `wordle` rootfs read-only.
- Updated `clusters/titania/apps/psuite/psuite-service.yaml` to add `loadBalancerSourceRanges` (RFC1918 ranges) to all `psuite` `LoadBalancer` services to restrict access to private networks.
- Reworked the Deluge WireGuard container in `clusters/titania/apps/torrents/deluge/deluge-wireguard-deploy.yaml` to remove `privileged: true`, set `allowPrivilegeEscalation: false`, drop `ALL` capabilities and explicitly `add: ["NET_ADMIN"]` to retain only the networking capability it needs.

### Testing

- Ran manifest linting with `yamllint` on the modified files and there were no syntax errors.
- Validated Kubernetes manifests with `kubeval` and `kubectl apply --dry-run=client -f` against the changed manifests and validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a097c39671c8327b83f445bbe4cf5f6)